### PR TITLE
Disable failIfMajorPerformanceCaveat

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -287,7 +287,7 @@ class HTML5Window
 						premultipliedAlpha: true,
 						stencil: Reflect.hasField(contextAttributes, "stencil") ? contextAttributes.stencil : false,
 						preserveDrawingBuffer: false,
-						failIfMajorPerformanceCaveat: true
+						failIfMajorPerformanceCaveat: false
 					};
 
 				var glContextType = ["webgl", "experimental-webgl"];


### PR DESCRIPTION
Disable failIfMajorPerformanceCaveat flag as we don't use extended functionality of WebGL dependent on that flag.